### PR TITLE
add composer script to run php-cs-fixer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -72,7 +72,8 @@
         ],
         "post-update-cmd": [
             "@auto-scripts"
-        ]
+        ],
+        "php-cs-fixer" : "./vendor/bin/php-cs-fixer fix --rules=@Symfony,-@PSR1,-@PSR2 src/"
     },
     "conflict": {
         "symfony/symfony": "*"


### PR DESCRIPTION
I think this is much easier to keep use the defined rules
run : `composer php-cs-fixer`