### PR TITLE
Add migration to update the skill entries that have null or empty image

### DIFF
--- a/src/Migrations/Version20200619015717.php
+++ b/src/Migrations/Version20200619015717.php
@@ -14,7 +14,7 @@ final class Version20200619015717 extends AbstractMigration
 {
     public function getDescription(): string
     {
-        return '';
+        return 'This migration replaces the null/empty values into the skill.image field by the default phpmexico logo.';
     }
 
     public function up(Schema $schema): void

--- a/src/Migrations/Version20200619015717.php
+++ b/src/Migrations/Version20200619015717.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20200619015717 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->abortIf(
+            'mysql' !== $this->connection->getDatabasePlatform()->getName(),
+            'Migration can only be executed safely on \'mysql\'.'
+        );
+
+        $this->addSql("UPDATE skill SET image_url = 'https://www.phpmexico.mx/images/logo-php.png' WHERE image_url IS NULL OR image_url = ''");
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->throwIrreversibleMigrationException('The skill.image_url cannot be set to null because we could lose information.');
+    }
+}


### PR DESCRIPTION
In order to update the skills with missing image #18 , we could run

```
bin/console doctrine:migrations:execute --up 20200619015717
```