### PR TITLE
Resize technology images to get same height and responsive fit-mode

### DIFF
--- a/assets/css/components/_tecnologias.scss
+++ b/assets/css/components/_tecnologias.scss
@@ -1,17 +1,15 @@
 .tecnologias{
-  .card-content {
-    img.responsive-img {
-      height: 100px !important;
-    }
-  }
-
-
   .tecnologia {
     filter: grayscale(.5);
     transition: filter .2s ease-out;
 
     &:hover {
       filter: none;
+    }
+
+    &__imagen {
+      height: 250px;
+      object-fit: scale-down;
     }
 
     &__titulo {

--- a/templates/index/index.html.twig
+++ b/templates/index/index.html.twig
@@ -73,7 +73,7 @@
             <div class="card card-hover z-depth-0 tecnologia">
               <a href="{{ path('skill_slug', {slug: skill.slug }) }}">
                 <div class="card-image">
-                  <img src="{{ skill.imageUrl }}" alt="{{ skill }}" class="responsive-img" width="100%">
+                  <img src="{{ skill.imageUrl }}" alt="{{ skill }}" class="tecnologia__imagen">
                 </div>
                 <div class="card-content">
                   <span class="card-title tecnologia__titulo">{{ skill }}</span>


### PR DESCRIPTION
It improves the way to display the technology/skill images to adapt to the parent container, using different logo sized it would see as the next image:

![image](https://user-images.githubusercontent.com/11241239/86535780-7716fd80-bea8-11ea-900f-cdfdef658a76.png)
