### PR TITLE
Creación de ruta beta para nuevo sitio

### DIFF
--- a/src/Controller/IndexController.php
+++ b/src/Controller/IndexController.php
@@ -13,6 +13,7 @@ use Psr\Log\LoggerInterface;
 use ReCaptcha\ReCaptcha;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
 
 class IndexController extends AbstractController
@@ -95,6 +96,14 @@ class IndexController extends AbstractController
         return $this->render('login.html.twig', [
             'form' => $form->createView(),
         ]);
+    }
+
+    /**
+     * @Route("/beta", name="beta")
+     */
+    public function beta(): Response
+    {
+        return $this->render('index/beta.html.twig');
     }
 
     private function inviteUser(string $email)

--- a/templates/index/beta.html.twig
+++ b/templates/index/beta.html.twig
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport"
+          content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="ie=edge">
+    <title>PHP Mexico | Beta</title>
+</head>
+<body>
+    <h1>En construccion...</h1>
+</body>
+</html>
+

--- a/tests/Functional/Controller/IndexControllerTest.php
+++ b/tests/Functional/Controller/IndexControllerTest.php
@@ -83,4 +83,13 @@ class IndexControllerTest extends WebTestCase
             ],
         ];
     }
+
+    /** @test */
+    public function betaShouldReturnASuccessStatus()
+    {
+        $client = self::createClient();
+        $client->request('GET', '/beta');
+        $responseCode = $client->getResponse()->getStatusCode();
+        $this->assertEquals(200, $responseCode);
+    }
 }


### PR DESCRIPTION
Se creó una ruta para la versión beta de la nueva página de PHP méxico.

Se puede accesar a través de la URL:
```
{host}/beta
```

El archivo relacionado a la vista se creó en:
```
{project}/templates/index.beta.html.twig
```

En dónde se puede ir colocando todo lo necesario para la página de inicio.

Este pull request soluciona el issue: https://github.com/phpmx/phpmexico/issues/52