### PR TITLE
En las instrucciones del README faltaba el comando composer install

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Windows, OS X & Linux::
 ```sh
 docker-compose up -d
 docker-compose exec -u web web bash
+composer install
 php bin/console doctrine:migra:migra
 ```
 


### PR DESCRIPTION
Creo que ya estaba el comando pero por alguna razón no aparecía 