### PR TITLE
Update Slack Invite Link

### DIFF
--- a/templates/menu.html.twig
+++ b/templates/menu.html.twig
@@ -12,7 +12,7 @@
             <li><a href="{{ path('jobs_plans') }}">Empresas</a></li>
             <li><a href="{{ path('jobs') }}">Trabajo</a></li>
             <li><a href="{{ path('meetup') }}">Eventos</a></li>
-            <li><a href="https://phpmx.slack.com" target="_blank" rel="noopener">Chat</a></li>
+            <li><a href="https://join.slack.com/t/phpmx/shared_invite/zt-l74bn93k-dJCkPpn1OwCcihdAbj4smA" target="_blank" rel="noopener">Chat</a></li>
             <li><a href="{{ path('profile') }}">Tu Perfil</a></li>
         </ul>
     </div>
@@ -22,6 +22,6 @@
     <li><a href="{{ path('jobs_plans') }}">Empresas</a></li>
     <li><a href="{{ path('jobs') }}">Trabajo</a></li>
     <li><a href="{{ path('meetup') }}">Eventos</a></li>
-    <li><a href="https://phpmx.slack.com" target="_blank" rel="noopener">Chat</a></li>
+    <li><a href="https://join.slack.com/t/phpmx/shared_invite/zt-l74bn93k-dJCkPpn1OwCcihdAbj4smA" target="_blank" rel="noopener">Chat</a></li>
     <li><a href="{{ path('profile') }}">Tu Perfil</a></li>
 </ul>


### PR DESCRIPTION
After the meetup I found that the original chat link (chat.phpmexico.mx) redirects to the site. After some discussion with @dmouse, @marianorenteria, and @gueroverde, @dmouse provided this non-expiring invite link. Slackbot's response to `slackin` is also updated to provide this same link.

@dmouse also recommended to create a route (phpmexico.mx/slack) so we do not have a hard time trying to remember the right link.

Depends on #77 