### PR TITLE
Configurar la ruta base (base path) con variable de entorno

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+# YouTube API Configuration
+VITE_YOUTUBE_API_KEY=your_youtube_api_key_here
+VITE_YOUTUBE_CHANNEL_ID=your_youtube_channel_id_here
+VITE_BASE_PATH=/phpmexico/

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,6 +30,7 @@ jobs:
         run: |
           echo VITE_YOUTUBE_API_KEY=${{ secrets.VITE_YOUTUBE_API_KEY }} >> .env
           echo VITE_YOUTUBE_CHANNEL_ID=${{ secrets.VITE_YOUTUBE_CHANNEL_ID }} >> .env
+          echo VITE_BASE_PATH=${{ secrets.VITE_BASE_PATH }} >> .env
       
       - name: Build the project
         run: npm run build

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -17,7 +17,7 @@ const router = createBrowserRouter([
     ],
   },
 ], {
-  basename: '/phpmexico',
+  basename: import.meta.env.VITE_BASE_PATH || '/',
 })
 
 ReactDOM.createRoot(document.getElementById('root')!).render(

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,7 +3,7 @@ import react from "@vitejs/plugin-react"
 import { defineConfig } from "vite"
 
 export default defineConfig({
-  base: "/phpmexico/",
+  base: process.env.VITE_BASE_PATH || "/",
   plugins: [react()],
   resolve: { 
     alias: {


### PR DESCRIPTION
Desacopla la configuración de la ruta base del código fuente usando una variable de entorno (VITE_BASE_PATH).

`vite.config.ts` ahora lee la ruta base desde process.env.VITE_BASE_PATH. Si la variable no existe, usará / como valor por defecto (ideal para producción y desarrollo local).
