### PR TITLE
Agregar CNAME en el workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,8 +35,12 @@ jobs:
       - name: Build the project
         run: npm run build
 
+      - name: Add CNAME file for custom domain
+        run: echo "phpmexico.mx" > ./dist/CNAME
+
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./dist
+          cname: phpmexico.mx


### PR DESCRIPTION
* Se agregó un paso para crear el archivo CNAME con el dominio phpmexico.mx en el directorio dist antes del despliegue.

* Se actualizó la acción de despliegue en GitHub Pages para establecer el dominio personalizado (cname) durante el proceso.